### PR TITLE
exta semicolon

### DIFF
--- a/TxDepthTest.cpp
+++ b/TxDepthTest.cpp
@@ -131,7 +131,7 @@ public:
     m_tpuHandle(NULL), m_spuIP(spu) { }
 
   virtual ~SPUStatusInterface(void)
-    { if (m_tpuHandle); { DllCloseTheTpu(m_tpuHandle); } }
+    { if (m_tpuHandle) { DllCloseTheTpu(m_tpuHandle); } }
 
   // after constuction, invoke 
   const int execute()


### PR DESCRIPTION
Could potentially get a double delete or a delete on a null ptr.